### PR TITLE
Load db config from environment variables

### DIFF
--- a/workshops/settings.py
+++ b/workshops/settings.py
@@ -74,14 +74,17 @@ WSGI_APPLICATION = 'workshops.wsgi.application'
 # Database
 # https://docs.djangoproject.com/en/2.2/ref/settings/#databases
 
+
+
+
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql',
-        'NAME': 'workshops',
-        'USER': 'postgres',
-        'PASSWORD': 'django1234',
-        'HOST': 'localhost',
-        'PORT': '5432',
+        'NAME': os.getenv('DB_NAME'),
+        'USER': os.getenv('DB_USER'),
+        'PASSWORD': os.getenv('DB_PASSWORD'),
+        'HOST': os.getenv('DB_HOST',  'localhost'),
+        'PORT': os.getenv('DB_PORT', '5432'),
     }
 }
 


### PR DESCRIPTION
# Load db config from environment variables

## Comments
This is a suggestion so we don hardcode the db credentials in the code.
We can read them from env vars.

# Evironment Variables
`DB_NAME`
`DB_USER`
`DB_PASSWORD`
`DB_HOST`: defaults to `localhost`
`DB_PORT`: defaults to `'5432'`